### PR TITLE
move to API v2 (WIP)

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -11,9 +11,8 @@ requirements:
     - python
     - pathlib 1.0  # [py2k]
     - enum 0.4.4 # [py2k]
-    - menpo 0.4.0a3
-    - menpo3d 0.1.0a3
-    - numpy
+    - menpo 0.4.0|>=0.4.1,<0.5.0  # Make sure we ignore the alpha
+    - menpo3d 0.1.0|>=0.1.1,<0.2.0  # Make sure we ignore the alpha
     - flask 0.10.1
     - flask-restful 0.2.12
     - cherrypy 3.6.0

--- a/landmarkerio/__init__.py
+++ b/landmarkerio/__init__.py
@@ -17,7 +17,7 @@ class CacheFile(Enum):
 
 class Server(Enum):
     origin = 'http://www.landmarker.io'
-    endpoint = '/api/v1/'
+    endpoint = '/api/v2/'
 
 
 class Endpoints(Enum):

--- a/landmarkerio/lmioconvert
+++ b/landmarkerio/lmioconvert
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+from pathlib import Path
+from os import path as p
+import menpo
+
+
+def convert_all_under_path(path):
+    for ljson_p in path.glob('**/*.ljson'):
+        print('converting: {}'.format(ljson_p))
+        menpo.io.export_landmark_file(menpo.io.import_landmark_file(ljson_p),
+                                      ljson_p, overwrite=True)
+
+
+if __name__ == "__main__":
+    from argparse import ArgumentParser
+    parser = ArgumentParser(
+        description=r"""
+        Convert old LJSON files to v2
+        """)
+    parser.add_argument("path", help="path that will be recusively searched for LJSON files")
+    ns = parser.parse_args()
+    convert_all_under_path(Path(p.abspath(p.expanduser(ns.path))))

--- a/landmarkerio/template.py
+++ b/landmarkerio/template.py
@@ -50,11 +50,11 @@ def build_json(groups, n_dims):
     labels = []
     for g in groups:
         connectivity += [[j + offset for j in i] for i in g.index]
-        offset += g.n
         labels.append({
             'label': g.label,
             'mask': list(range(offset, offset + g.n))
         })
+        offset += g.n
 
     lm_json = {
         'labels': labels,

--- a/landmarkerio/template.py
+++ b/landmarkerio/template.py
@@ -43,13 +43,28 @@ def group_to_json(group, n_dims):
     return group_json
 
 
-def groups_to_json(groups, n_dims):
-    lm_json = {
-        'version': 1,
-        'groups': []
-    }
+def build_json(groups, n_dims):
+    n_points = sum(g.n for g in groups)
+    offset = 0
+    connectivity = []
+    labels = []
     for g in groups:
-        lm_json['groups'].append(group_to_json(g, n_dims))
+        connectivity += [[j + offset for j in i] for i in g.index]
+        offset += g.n
+        labels.append({
+            'label': g.label,
+            'mask': list(range(offset, offset + g.n))
+        })
+
+    lm_json = {
+        'labels': labels,
+        'landmarks': {
+            'connectivity': connectivity,
+            'points': [[None] * n_dims] * n_points
+        },
+        'version': 2,
+    }
+
     return lm_json
 
 
@@ -57,7 +72,7 @@ def load_template(path, n_dims):
     with open(path) as f:
         ta = f.read().strip().split('\n\n')
     groups = [parse_group(g) for g in ta]
-    return groups_to_json(groups, n_dims)
+    return build_json(groups, n_dims)
 
 
 class TemplateAdapter(object):

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setup(name='landmarkerio',
       install_requires=install_requires,
       scripts=[join('landmarkerio', 'lmio'),
                join('landmarkerio', 'lmioserve'),
-               join('landmarkerio', 'lmiocache')]
+               join('landmarkerio', 'lmiocache'),
+               join('landmarkerio', 'lmioconvert')]
       )

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,12 @@ versioneer.versionfile_build = '{}/_version.py'.format(project_name)
 versioneer.tag_prefix = 'v'  # tags are like v1.2.0
 versioneer.parentdir_prefix = project_name + '-'  # dirname like 'menpo-v1.2.0'
 
-install_requires = ['menpo>=0.4.a3',
-                    'numpy>=1.9.0',
+install_requires = ['menpo>=0.4.0,<0.5',
+                    'menpo3d>=0.1.0,<0.2',
                     'Flask>=0.10.1',
-                    'Flask-RESTful>=0.2.11',
-                    'CherryPy==3.6.0',
-                    'joblib>=0.8.2']
+                    'Flask-RESTful>=0.2.12',
+                    'CherryPy>=3.6.0',
+                    'joblib>=0.8.4']
 
 if sys.version_info.major == 2:
     install_requires.extend(['enum>=0.4.4', 'pathlib>=1.0'])


### PR DESCRIPTION
This PR bumps the landmarker server to use v2 of the API. The changes to the LJSON format are documented [here](https://github.com/menpo/landmarker.io/wiki/API:-Moving-from-v1-to-v2). A brief rundown of what's changed

- The LJSON format has been updated to match Menpo's landmark model (a single collection of points with optional connectivity information grouped into potentially overlapping subsets called 'labels'). This is a necessary step towards being able to build the landmarker.io widget for Menpo.
- A conversion utility `lmioconvert` is provided. This tool recursively searches a provided path for LJSON files and updates them to the new format.
- The endpoint of the api has changed from `/api/v1/` to `/api/v2/` to accommodate the changes. Once this PR is merged and a new release of landmarkerio-server made, landmarker.io will be updated to look for the new API by default. If no new API is found but a v1 API is, the landmarker will launch a legacy page that will still work with the old API and will provide information for moving to v2.


## TODO

- [x] Merge https://github.com/menpo/menpo/pull/540 to add LJSON v2 support to Menpo
- [x] Release a new version of menpo and menpo3d
- [x] Bump the dependencies on landmarkerio-server to match the new releases of menpo and menpo3d
- [x] Merge https://github.com/menpo/landmarker.io/pull/82 and make a new landmarker.io release
- [x] Merge this PR, release new landmarkerio-server