### PR TITLE
Yaml template

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ SSH port tunnelling is an easy secure solution.
 landmarkerio server requires [Menpo](https://github.com/menpo/menpo)
 [Menpo3d](https://github.com/menpo/menpo) to run. As these have somewhat
 complex dependencies, by far the easiest way to install landmarkerio, is
-with conda. On OS X, Linux or Windows, just install conda and then 
+with conda. On OS X, Linux or Windows, just install conda and then
 ```
 >> conda install -c menpo landmarkerio
 ```
@@ -70,77 +70,46 @@ You get help on the tool just as you would expect
 Templates restrict the set of allowed annotations and give the annotations
 semantic meaning. The user of the server has full control over what
 annotations the user of landmarker.io should complete by declaring *templates*.
-A template file is simple a `.txt` file. The filename is the name of the template.
-An example template is provided below.
+A template file is simple a `.yml` file. The filename is the name of the template.
+
+An example template is provided below, a [more detailed specification](https://github.com/menpo/landmarker.io/wiki/Templates-specification) is also available on the landmarker.io wiki.
 
 **`face.txt`**
-```text
-mouth 6
-
-nose 3
-0 1
-1 2
-
-l_eye 8
-0:7
-7 0
-
-r_eye 8
-0:7
-7 0
-
-chin 1
-
+```face.yaml
+# groups key marks the template itself, anything else is metadata
+groups:
+  # The first landmark group is called 'mouth'
+  # it is made up of six points
+  - label: mouth
+    points: 6
+  - label: nose
+    points: 3
+    # Pairs of numbers immediately following a declaration
+    # of a group specify connectivity information. Here,
+    # The first entry of the nose group is joined to the second
+    # (0-based indexing) and the second to the third. This will
+    # be visualized in the landmarker.
+    connectivity:
+      - 0 1
+      - 1 2
+  - label: left_eye
+    points: 8
+    connectivity:
+      # Slice notation is abused to construct straight chains
+      # of connectivity. This is expanded out into
+      # 0 1
+      # 1 2
+      # ...
+      # 6 7
+      - 0:7
+      - 7 0
+  - label: right_eye
+    points: 8
+    # The cycle shortcut
+    connectivity: cycle
+  - label: chin
+    points: 1
 ```
-We now annotate the file to explain the syntax:
-
-**`face.txt`**
-```
-# This template is called 'face'. All saved landmarks
-# will have the name 'face'
-```
-
-```text
-mouth 6
-# The first landmark group is called 'mouth'
-# it is made up of six points
-
-# A single line of whitespace seperates different
-# groups from each other
-nose 3
-# The second group is 'nose' - 3 points.
-0 1
-1 2
-# Pairs of numbers immediately following a declaration
-# of a group specify connectivity information. Here,
-# The first entry of the nose group is joined to the second
-# (0-based indexing) and the second to the third. This will
-# be visualized in the landmarker.
-
-l_eye 8
-0:7
-# Slice notation is abused to construct straight chains
-# of connectivity. This is expanded out into
-# 0 1
-# 1 2
-# ...
-# 6 7
-7 0
-# We can mix slicing with the pairings used above.
-# Here we add a final connection back around from the 8th
-# landmark to the first to complete the circle.
-
-r_eye 8
-0:7
-7 0
-
-chin 1
-# Connectivity information is completely optional
-
-```
-The template format is intentionally extremely simple. The full
-syntax is as displayed above. Note that there is no support for comments
-so the second block is not a legal template.
 
 #### Storing templates
 
@@ -149,9 +118,3 @@ A path to a folder can be provided as the `-t` argument to
 `landmarkerio`. If no argument is provided, `lmio` looks for
 the folder `~/.lmiotempates`. This provides a convenient place to
 store frequently used templates.
-
-Finally, it should be noted that landmarkerio currently doesn't support
-switching templates (see
-[landmarkerio#53](https://github.com/menpo/landmarker.io/issues/53)) and
-as a result only the first template alphabetically is used for the time
-being. This is only temporary.

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     - flask-restful 0.2.12
     - cherrypy 3.6.0
     - joblib 0.8.4
+    - pyyaml 3.11
 
 test:
   imports:

--- a/landmarkerio/__init__.py
+++ b/landmarkerio/__init__.py
@@ -4,6 +4,7 @@ from enum import Enum
 class FileExt(Enum):
     lm = '.ljson'
     template = '.yml'
+    old_template = '.txt'
     collection = '.txt'
 
 

--- a/landmarkerio/__init__.py
+++ b/landmarkerio/__init__.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class FileExt(Enum):
     lm = '.ljson'
-    template = '.txt'
+    template = '.yml'
     collection = '.txt'
 
 

--- a/landmarkerio/lmio
+++ b/landmarkerio/lmio
@@ -6,10 +6,11 @@ import tempfile
 from landmarkerio.cache import cache_assets, filepath_as_asset_id_under_dir
 from landmarkerio.serverconfigs import serve_from_cache, serve_with_cherrypy
 from landmarkerio.landmark import InplaceFileLmAdapter
+from landmarkerio import TEMPLATE_DINAME
 
 
 def main(mode, asset_dir, recursive=False, ext=None, template_dir=None,
-         collection_dir=None, cache_dir=None, dev=False, port=5000, public=False,
+         collection_dir=None, cache_dir=None, dev=False, port=5000, public=False, rewrite_templates=False,
          glob=None):
     r"""
 
@@ -24,13 +25,12 @@ def main(mode, asset_dir, recursive=False, ext=None, template_dir=None,
     lm_adapter = InplaceFileLmAdapter(asset_ids_to_path)
     app = serve_from_cache(mode, cache_dir, lm_adapter,
                            template_dir=template_dir,
+                           rewrite_templates=rewrite_templates,
                            collection_dir=collection_dir, dev=dev)
     if not dev and port == 5000:
         webbrowser.open("http://www.landmarker.io/?mode={}".format(mode))
     serve_with_cherrypy(app, port=port, public=public)
 
-
-from landmarkerio import TEMPLATE_DINAME
 
 if __name__ == "__main__":
     from argparse import ArgumentParser
@@ -76,6 +76,9 @@ if __name__ == "__main__":
                         help="Listen to public requests (0.0.0.0).")
     parser.add_argument("-p", "--port",
                         help="The port to host the server on. 5000 by default")
+    parser.add_argument('--rewrite_templates', action='store_true',
+                        help="Rewrite old .txt template to the new .yml"
+                             "format")
     ns = parser.parse_args()
     port = ns.port
     if port is None:
@@ -86,4 +89,5 @@ if __name__ == "__main__":
     main(ns.mode, ns.path, recursive=ns.recursive, ext=ns.ext,
          template_dir=ns.templates, collection_dir=ns.collections,
          cache_dir=ns.cache, dev=ns.dev, port=port, public=ns.public,
+         rewrite_templates=ns.rewrite_templates,
          glob=ns.glob)

--- a/landmarkerio/lmio
+++ b/landmarkerio/lmio
@@ -10,7 +10,7 @@ from landmarkerio import TEMPLATE_DINAME
 
 
 def main(mode, asset_dir, recursive=False, ext=None, template_dir=None,
-         collection_dir=None, cache_dir=None, dev=False, port=5000, public=False, rewrite_templates=False,
+         collection_dir=None, cache_dir=None, dev=False, port=5000, public=False, upgrade_templates=False,
          glob=None):
     r"""
 
@@ -25,7 +25,7 @@ def main(mode, asset_dir, recursive=False, ext=None, template_dir=None,
     lm_adapter = InplaceFileLmAdapter(asset_ids_to_path)
     app = serve_from_cache(mode, cache_dir, lm_adapter,
                            template_dir=template_dir,
-                           rewrite_templates=rewrite_templates,
+                           upgrade_templates=upgrade_templates,
                            collection_dir=collection_dir, dev=dev)
     if not dev and port == 5000:
         webbrowser.open("http://www.landmarker.io/?mode={}".format(mode))
@@ -76,9 +76,11 @@ if __name__ == "__main__":
                         help="Listen to public requests (0.0.0.0).")
     parser.add_argument("-p", "--port",
                         help="The port to host the server on. 5000 by default")
-    parser.add_argument('--rewrite_templates', action='store_true',
-                        help="Rewrite old .txt template to the new .yml"
-                             "format")
+    parser.add_argument('--upgrade-templates', action='store_true',
+                        help="Rewrite old .txt template to the new .yml "
+                             "format and delete old .txt files from the "
+                             "template directory (consider backing up the"
+                             "directory first).")
     ns = parser.parse_args()
     port = ns.port
     if port is None:
@@ -89,5 +91,5 @@ if __name__ == "__main__":
     main(ns.mode, ns.path, recursive=ns.recursive, ext=ns.ext,
          template_dir=ns.templates, collection_dir=ns.collections,
          cache_dir=ns.cache, dev=ns.dev, port=port, public=ns.public,
-         rewrite_templates=ns.rewrite_templates,
+         upgrade_templates=ns.upgrade_templates,
          glob=ns.glob)

--- a/landmarkerio/lmioserve
+++ b/landmarkerio/lmioserve
@@ -41,14 +41,19 @@ if __name__ == "__main__":
                              "at this path. The file should contain the "
                              "username on the first line, the password on the "
                              "second, and no other content.")
+    parser.add_argument('--rewrite_templates', action='store_true',
+                        help="Rewrite old .txt template to the new .yml"
+                             "format")
     ns = parser.parse_args()
     lm_adapter = SeparateDirFileLmAdapter(ns.landmarks)
     if ns.basicauth is not None:
         username, password = parse_username_and_password_file(ns.basicauth)
     else:
         username, password = None, None
+
     app = serve_from_cache(ns.mode, ns.cache, lm_adapter,
                            template_dir=ns.templates,
+                           rewrite_templates=ns.rewrite_templates,
                            collection_dir=ns.collections, dev=ns.dev,
                            username=username, password=password)
     if ns.port is None:

--- a/landmarkerio/lmioserve
+++ b/landmarkerio/lmioserve
@@ -41,9 +41,11 @@ if __name__ == "__main__":
                              "at this path. The file should contain the "
                              "username on the first line, the password on the "
                              "second, and no other content.")
-    parser.add_argument('--rewrite_templates', action='store_true',
-                        help="Rewrite old .txt template to the new .yml"
-                             "format")
+    parser.add_argument('--upgrade-templates', action='store_true',
+                        help="Rewrite old .txt template to the new .yml "
+                             "format and delete old .txt files from the "
+                             "template directory (consider backing up the"
+                             "directory first).")
     ns = parser.parse_args()
     lm_adapter = SeparateDirFileLmAdapter(ns.landmarks)
     if ns.basicauth is not None:
@@ -53,7 +55,7 @@ if __name__ == "__main__":
 
     app = serve_from_cache(ns.mode, ns.cache, lm_adapter,
                            template_dir=ns.templates,
-                           rewrite_templates=ns.rewrite_templates,
+                           upgrade_templates=ns.upgrade_templates,
                            collection_dir=ns.collections, dev=ns.dev,
                            username=username, password=password)
     if ns.port is None:

--- a/landmarkerio/serverconfigs.py
+++ b/landmarkerio/serverconfigs.py
@@ -28,7 +28,7 @@ def serve_with_cherrypy(app, port=5000, public=False):
 
 
 def serve_from_cache(mode, cache_dir, lm_adapter, template_dir=None,
-                     rewrite_templates=False, collection_dir=None, dev=False,
+                     upgrade_templates=False, collection_dir=None, dev=False,
                      username=None, password=None):
     r"""
 
@@ -48,7 +48,7 @@ def serve_from_cache(mode, cache_dir, lm_adapter, template_dir=None,
         raise ValueError("mode must be 'image' or 'mesh'")
     add_mode_endpoint(api, mode)
     template_adapter = CachedFileTemplateAdapter(
-        n_dims, template_dir=template_dir, rewrite_templates=rewrite_templates)
+        n_dims, template_dir=template_dir, upgrade_templates=upgrade_templates)
     add_template_endpoints(api, template_adapter)
     add_lm_endpoints(api, lm_adapter, template_adapter)
     if collection_dir is not None:

--- a/landmarkerio/serverconfigs.py
+++ b/landmarkerio/serverconfigs.py
@@ -28,11 +28,12 @@ def serve_with_cherrypy(app, port=5000, public=False):
 
 
 def serve_from_cache(mode, cache_dir, lm_adapter, template_dir=None,
-                     collection_dir=None, dev=False, username=None,
-                     password=None):
+                     rewrite_templates=False, collection_dir=None, dev=False,
+                     username=None, password=None):
     r"""
 
     """
+
     api, app = lmio_api(dev=dev, username=username, password=password)
     if dev:
         app.debug = True
@@ -46,8 +47,8 @@ def serve_from_cache(mode, cache_dir, lm_adapter, template_dir=None,
     else:
         raise ValueError("mode must be 'image' or 'mesh'")
     add_mode_endpoint(api, mode)
-    template_adapter = CachedFileTemplateAdapter(n_dims,
-                                                 template_dir=template_dir)
+    template_adapter = CachedFileTemplateAdapter(
+        n_dims, template_dir=template_dir, rewrite_templates=rewrite_templates)
     add_template_endpoints(api, template_adapter)
     add_lm_endpoints(api, lm_adapter, template_adapter)
     if collection_dir is not None:

--- a/landmarkerio/template.py
+++ b/landmarkerio/template.py
@@ -33,16 +33,23 @@ def parse_connectivity(index_lst, n):
 def load_yaml_template(filepath, n_dims):
     with open(filepath) as f:
         data = yaml.load(f.read())
+
+        if 'groups' in data:
+            raw_groups = data['groups']
+        elif 'template' in data:
+            raw_groups = data['template']
+        else:
+            raise KeyError(
+                "Missing 'groups' or 'template' key in yaml file %s"
+                % filepath)
+
         groups = []
 
-        for label, group in data.iteritems():
+        for group, index in enumerate(raw_groups):
 
-            # Simple case with only a length
-            if isinstance(group, (int, str)):
-                groups.append(Group(label, int(group), []))
-                continue
+            label = group.get('label', index)  # Allow simple ordered groups
 
-            n = group['points']
+            n = group['points']  # Should raise KeyError by design if missing
             connectivity = group.get('connectivity', [])
 
             if isinstance(connectivity, list):
@@ -51,8 +58,7 @@ def load_yaml_template(filepath, n_dims):
                 index = parse_connectivity(
                     ['0:%d' % (n - 1), '%d 0' % (n - 1)], n)
             else:
-                # Couldn't parse connectivity, safe default
-                index = []
+                index = []  # Couldn't parse connectivity, safe default
 
             groups.append(Group(label, n, index))
 

--- a/landmarkerio/template.py
+++ b/landmarkerio/template.py
@@ -36,8 +36,6 @@ def load_yaml_template(filepath, n_dims):
 
         if 'groups' in data:
             raw_groups = data['groups']
-        elif 'template' in data:
-            raw_groups = data['template']
         else:
             raise KeyError(
                 "Missing 'groups' or 'template' key in yaml file %s"
@@ -54,7 +52,7 @@ def load_yaml_template(filepath, n_dims):
 
             if isinstance(connectivity, list):
                 index = parse_connectivity(connectivity, n)
-            elif connectivity is 'circular' or 'cycle':
+            elif connectivity is 'cycle':
                 index = parse_connectivity(
                     ['0:%d' % (n - 1), '%d 0' % (n - 1)], n)
             else:

--- a/landmarkerio/template.py
+++ b/landmarkerio/template.py
@@ -43,7 +43,7 @@ def load_yaml_template(filepath, n_dims):
 
         groups = []
 
-        for group, index in enumerate(raw_groups):
+        for index, group in enumerate(raw_groups):
 
             label = group.get('label', index)  # Allow simple ordered groups
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ install_requires = ['menpo>=0.4.0,<0.5',
                     'Flask>=0.10.1',
                     'Flask-RESTful>=0.2.12',
                     'CherryPy>=3.6.0',
-                    'joblib>=0.8.4']
+                    'joblib>=0.8.4',
+                    'PyYaml>=3.11']
 
 if sys.version_info.major == 2:
     install_requires.extend(['enum>=0.4.4', 'pathlib>=1.0'])


### PR DESCRIPTION
As we discussed this implements an alternative template format as YAML.
All files in the templates directory with `yaml` or `yml` extensions will be parsed this way.

The groups are dicts defined in a top-level `groups` array. They consists of the following keys: `label` (required), `points` (required) and `connectivity` (optional).

`connectivity` is defined as before as a list of links `1 2` to link 1 and 2 together and `1:5` to make a chain from 1 to 5, It is also possible to set it to `cycle` as a shorthand to `0:7, `0 1` (for 8 points).

fixes #9 