### PR TITLE
Upgrade menpo and menpo3d versions

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -10,8 +10,8 @@ requirements:
   run:
     - python
     - pathlib 1.0  # [py2k]
-    - menpo 0.6.*
-    - menpo3d 0.3.*
+    - menpo 0.7.*
+    - menpo3d 0.4.*
     - flask 0.10.1
     - flask-restful 0.2.12
     - cherrypy 3.8.0

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from os.path import join
 import sys
 import versioneer
 
-install_requires = ['menpo>=0.6,<0.7',
-                    'menpo3d>=0.3,<0.4',
+install_requires = ['menpo>=0.7,<0.8',
+                    'menpo3d>=0.4,<0.5',
                     'Flask>=0.10.1',
                     'Flask-RESTful>=0.2.12',
                     'CherryPy>=3.8.0',


### PR DESCRIPTION
No errors or warnings when `lmio image` or `lmio mesh` is run.